### PR TITLE
Fixes2018

### DIFF
--- a/xkcd.py
+++ b/xkcd.py
@@ -1,4 +1,5 @@
 import urllib.request,os,random,tkinter.filedialog
+import re
 print('Romance,Sarcasm,Math and Language\nWelcome to xkcd Downloader 1.0\n\nAccepted Inputs :')
 print('all : downloads all xkcd comics from the beginning to the latest one')
 print('first : downloads the first xkcd comic')
@@ -9,6 +10,11 @@ print('[Range] : downloads the xkcd comics in that range',' ','Example:5-19')
 print('If no input is given : downloads the latest xkcd comic by default')
 print('\nYou can also specify the directory you want to download the comic(s) to.')
 print('Default directory is the current working directory.\n')
+def cleanhtml(raw_html):
+    cleanr = re.compile('<.*?>')
+    cleantext = re.sub(cleanr, '', raw_html)
+    return cleantext
+
 def f(n):
     try:
         page = 'http://xkcd.com/' + n + '/'
@@ -22,7 +28,15 @@ def f(n):
         ts = text.find('ctitle')
         te = text.find('<ul class="comicNav"')
         title = text[ts+8:te-8]
-        img = title + '.jpg'
+        title = cleanhtml(title)
+        title = re.sub("[/]",'_',title)
+        link=re.sub(re.compile(".*http[s]*://",re.I),'https://',link)
+        print("Link: {0}".format(link))
+        if link[-4:-3]=='.':
+            ext=link[-4:]
+        else:
+            ext=".jpg"
+        img = "%04d" % int(n) + '-'+ title + ext
         #Now downloading the image
         print('Now downloading - '+ img)
         urllib.request.urlretrieve(link,img)
@@ -37,7 +51,8 @@ def latest():
         #Now finding the latest comic number
         ns = content.find('this comic:')
         ne = content.find('<br />\\nImage URL')
-        newest = content[ns+28:ne-1]
+        newest = re.sub('[^\d]','',content[ns+28:ne-1])
+        print(newest)
         return int(newest)
     except urllib.error.URLError:
         print('Network Error')
@@ -87,7 +102,7 @@ elif position > 0:
     ll = int(number[0:position])
     ul = int(number[position+1:len(number)])
     if ul>ll and ul <= (latest()) and ll>0:
-        for i in range(ll,ul):
+        for i in range(ll,ul+1):
             if i != 404:
                 f(str(i))
             else:

--- a/xkcd.py
+++ b/xkcd.py
@@ -131,4 +131,5 @@ else:
     except ValueError:
             print('Invalid input')
 
-x = input('\nPress Enter to exit ...')
+#x = input('\nPress Enter to exit ...')
+print("Download complete")

--- a/xkcd.py
+++ b/xkcd.py
@@ -21,15 +21,30 @@ def f(n):
         response = urllib.request.urlopen(page)
         text = str(response.read())
         #Now finding the link of the comic on the page
-        ls = text.find('embedding')
-        le = text.find('<div id="transcript"')
-        link = text[ls+12:le-2]
-        #Now finding the title of the comic
-        ts = text.find('ctitle')
-        te = text.find('<ul class="comicNav"')
-        title = text[ts+8:te-8]
-        title = cleanhtml(title)
-        title = re.sub("[/]",'_',title)
+        if n=='404':
+            print("404: comic not found!")
+            link='https://www.explainxkcd.com/wiki/images/9/92/not_found.png'
+            title='404'
+        else:
+            if n=='1037':
+                print("UMWELT")
+                link='https://www.explainxkcd.com/wiki/images/f/ff/umwelt_the_void.jpg'
+            elif n=='1608':
+                print("Hoverboard game - downloading PNG snapshot")
+                link='https://www.explainxkcd.com/wiki/images/4/41/hoverboard.png'
+            elif n=='1663':
+                print("Garden - downloading PNG snapshot")
+                link='https://www.explainxkcd.com/wiki/images/c/ce/garden.png'
+            else:
+                ls = text.find('embedding')
+                le = text.find('<div id="transcript"')
+                link = text[ls+12:le-2]
+            #Now finding the title of the comic
+            ts = text.find('ctitle')
+            te = text.find('<ul class="comicNav"')
+            title = text[ts+8:te-8]
+            title = cleanhtml(title)
+            title = re.sub("[/]",'_',title)
         link=re.sub(re.compile(".*http[s]*://",re.I),'https://',link)
         print("Link: {0}".format(link))
         if link[-4:-3]=='.':
@@ -42,6 +57,7 @@ def f(n):
         urllib.request.urlretrieve(link,img)
         print('Done')
     except urllib.error.URLError:
+        print("URL error")
         exit()
 
 def latest():
@@ -79,23 +95,12 @@ if number == 'latest' or number == '':
     f(str(latest()))
 elif number == 'first':
     f(str(1))
-elif number == '404':
-    print('Error 404:Comic Not Found\nDownloading latest comic in place')
-    f(str(latest()))
 elif number == 'random':
     val = str(random.randint(1, latest()))
-    if val == '404':
-        print('Error 404:Comic Not Found\nDownloading latest comic in place')
-        f(str(latest()))
-    else:
-        f(val)
+    f(str(latest()))
 elif number == 'all':
     for o in range(1,latest()):
-        if o != 404:
-            f(str(o))
-        else:
-            print('Error 404:Comic Not Found')
-            o = o+1
+        f(str(o))
             
 elif position > 0:
     #For the range input
@@ -103,11 +108,7 @@ elif position > 0:
     ul = int(number[position+1:len(number)])
     if ul>ll and ul <= (latest()) and ll>0:
         for i in range(ll,ul+1):
-            if i != 404:
-                f(str(i))
-            else:
-                print('Error 404:Comic Not Found')
-                i=i+1
+            f(str(i))
             
     elif ul>(latest()) or ll <=0:
         print('Invalid range ...')

--- a/xkcd.py
+++ b/xkcd.py
@@ -17,24 +17,29 @@ def cleanhtml(raw_html):
 
 def f(n):
     try:
-        page = 'http://xkcd.com/' + n + '/'
-        response = urllib.request.urlopen(page)
-        text = str(response.read())
+
         #Now finding the link of the comic on the page
-        if n=='404':
+        if str(n)=="404":
             print("404: comic not found!")
             link='https://www.explainxkcd.com/wiki/images/9/92/not_found.png'
             title='404'
+            return
         else:
+            page = 'http://xkcd.com/' + n + '/'
+            response = urllib.request.urlopen(page)
+            text = str(response.read())
             if n=='1037':
                 print("UMWELT")
                 link='https://www.explainxkcd.com/wiki/images/f/ff/umwelt_the_void.jpg'
+                return
             elif n=='1608':
-                print("Hoverboard game - downloading PNG snapshot")
+                print("1608 Hoverboard game")
                 link='https://www.explainxkcd.com/wiki/images/4/41/hoverboard.png'
+                return
             elif n=='1663':
-                print("Garden - downloading PNG snapshot")
+                print("1663 Garden")
                 link='https://www.explainxkcd.com/wiki/images/c/ce/garden.png'
+                return
             else:
                 ls = text.find('embedding')
                 le = text.find('<div id="transcript"')
@@ -45,7 +50,7 @@ def f(n):
             title = text[ts+8:te-8]
             title = cleanhtml(title)
             title = re.sub("[/]",'_',title)
-        link=re.sub(re.compile(".*http[s]*://",re.I),'https://',link)
+            link=re.sub(re.compile(".*http[s]*://",re.I),'https://',link)
         print("Link: {0}".format(link))
         if link[-4:-3]=='.':
             ext=link[-4:]
@@ -118,12 +123,12 @@ else:
     try:
         if 1 <= int(number) <= (latest()):
             #Calling the function for a direct input
-            f(number)
+            f(str(number))
         elif int(number) > (latest()):
             print('Not yet published ...')
         elif int(number) <= 0:
-            print('Enter a number between 1 and the latest ...')        
+            print('Enter a number between 1 and the latest ...')
     except ValueError:
             print('Invalid input')
-    
+
 x = input('\nPress Enter to exit ...')

--- a/xkcd.py
+++ b/xkcd.py
@@ -16,6 +16,10 @@ def cleanhtml(raw_html):
     return cleantext
 
 def f(n):
+    # n is expected to be an int, convert to str
+    if int(n) <= 0:
+        exit("{0} is not a valid comic number")
+    n=str(int(n)) # to be really sure
     try:
 
         #Now finding the link of the comic on the page
@@ -97,15 +101,15 @@ except OSError:
 position = number.find('-')
 
 if number == 'latest' or number == '':
-    f(str(latest()))
+    f(latest())
 elif number == 'first':
-    f(str(1))
+    f(1)
 elif number == 'random':
     val = str(random.randint(1, latest()))
-    f(str(latest()))
+    f(val)
 elif number == 'all':
     for o in range(1,latest()):
-        f(str(o))
+        f(o)
             
 elif position > 0:
     #For the range input
@@ -113,7 +117,7 @@ elif position > 0:
     ul = int(number[position+1:len(number)])
     if ul>ll and ul <= (latest()) and ll>0:
         for i in range(ll,ul+1):
-            f(str(i))
+            f(i)
             
     elif ul>(latest()) or ll <=0:
         print('Invalid range ...')
@@ -123,7 +127,7 @@ else:
     try:
         if 1 <= int(number) <= (latest()):
             #Calling the function for a direct input
-            f(str(number))
+            f(number)
         elif int(number) > (latest()):
             print('Not yet published ...')
         elif int(number) <= 0:


### PR DESCRIPTION
Hi, thanks for this script, just what I was looking for.
I'm new to github (and pretty new to Python as well...), so apologies if I've gotten something about the process wrong and my code isn't very elegant yet.
I've downloaded up to 2006 with the script and patched for exceptions as they came up.

Fixes:
- Minor fix to latest (range didn't cope with links changing to https, I guess) which strips non digits from result.
- Changed comic range to be inclusive of last comic.
- Keeps file extension of downloaded file
- Replaces forward slashes in titles with underscores (issue on nix/mac - amusingly came up in PC/Mac comic)
- Does not attempt download on the weird comics (moved 404 and other exception case testing into f() to de-duplicate checks).
- Cleans extra HTML coming back from title search (I can't remember what comic this was needed for)

Enhancements (you may want to trim these out):
- Adds numeric prefix to file names (eg 1234-Title.png) so they sort in publication order.
- Optional command line arguments --nogui, --comic, --dest for scripted/command line use
